### PR TITLE
Changes for RGP Lua 0.59

### DIFF
--- a/src/articulation_autoposition_rolled_chords.lua
+++ b/src/articulation_autoposition_rolled_chords.lua
@@ -1,0 +1,70 @@
+function plugindef()
+    finaleplugin.RequireSelection = true
+    finaleplugin.Author = "Robert Patterson"
+    finaleplugin.Copyright = "CC0 https://creativecommons.org/publicdomain/zero/1.0/"
+    finaleplugin.Version = "1.0"
+    finaleplugin.Date = "December 26, 2021"
+    finaleplugin.CategoryTags = "Articulation"
+    finaleplugin.MinJWLuaVersion = 0.59
+    return "Autoposition Rolled Chord Articulations", "Autoposition Rolled Chord Articulations", "Autoposition Rolled Chord Articulations"
+end
+
+local path = finale.FCString()
+path:SetRunningLuaFolderPath()
+package.path = package.path .. ";" .. path.LuaString .. "?.lua"
+local note_entry = require("library.note_entry")
+
+local config = {
+    extend_across_staves = true
+}
+
+function calc_top_bot_page_pos(search_region)
+    local success = false
+    local top_page_pos = -math.huge
+    local bot_page_pos = math.huge
+    local left_page_pos = math.huge
+    for entry in eachentry(search_region) do
+        if entry:IsRest() then
+            break
+        end
+        local em = finale.FCEntryMetrics()
+        if em:Load(entry) then
+            success = true
+            if em.TopPosition > top_page_pos then
+                top_page_pos = em.TopPosition
+            end
+            if em.BottomPosition < bot_page_pos then
+                bot_page_pos = em.BottomPosition
+            end
+            if em.FirstAccidentalPosition < left_page_pos then
+                left_page_pos = em.FirstAccidentalPosition
+            end
+            em:FreeMetrics()
+        end
+    end
+    return success, top_page_pos, bot_page_pos, left_page_pos
+end
+
+function articulation_autoposition_rolled_chords()
+    for entry in eachentry(finenv.Region()) do
+        local artics = entry:CreateArticulations()
+        for artic in each(artics) do
+            if artic.Visible then
+                local artic_def = artic:CreateArticulationDef()
+                if artic_def.CopyMainSymbol and not artic_def.CopyMainSymbolHorizontally then
+                    local search_region = note_entry.get_music_region(entry)
+                    if config.extend_across_staves then
+                        search_region.EndStaff = finenv.Region().EndStaff
+                    end
+                    local success, top_page_pos, bot_page_pos, left_page_pos = calc_top_bot_page_pos(search_region)
+                    if success then
+
+    --                    finenv.UI():AlertInfo("t: " .. tostring(top_page_pos) .. " b: " .. tostring(bot_page_pos) .. " l: " .. tostring(left_page_pos), "articulation_autoposition_rolled_chords")
+                    end
+                end
+            end
+        end
+    end
+end
+
+articulation_autoposition_rolled_chords()

--- a/src/articulation_autoposition_rolled_chords.lua
+++ b/src/articulation_autoposition_rolled_chords.lua
@@ -9,7 +9,10 @@ function plugindef()
     return "Autoposition Rolled Chord Articulations", "Autoposition Rolled Chord Articulations", "Autoposition Rolled Chord Articulations"
 end
 
-require('mobdebug').start()
+-- This script requires the VerticalCopyToPos property on FCArticulation, which was added in v0.59 of RGP Lua
+-- Therefore, it is marked not to load in any earlier version.
+
+--require('mobdebug').start()
 
 local path = finale.FCString()
 path:SetRunningLuaFolderPath()
@@ -18,7 +21,13 @@ local note_entry = require("library.note_entry")
 local articulation = require("library.articulation")
 
 local config = {
-    extend_across_staves = true
+    extend_across_staves = true,
+    -- per Ted Ross p. 198-9, the vertical extent is "approximately 1 space above and below" (counted from the staff position),
+    --    which means a half space from the note tips. But Gould has them closer, so we'll compromise here.
+     vertical_padding = 6,           -- 1/4 space
+    -- per Ted Ross p. 198-9, the rolled chord mark precedes the chord by 3/4 space, and Gould (p. 131ff.) seems to agree
+    --    from looking at illustrations
+     horizontal_padding = 18         -- 3/4 space
 }
 
 function calc_top_bot_page_pos(search_region)
@@ -67,12 +76,24 @@ function articulation_autoposition_rolled_chords()
                             search_region.EndStaff = finenv.Region().EndStaff
                         end
                     end
-                    if artic.Visible then
-                        local success, top_page_pos, bot_page_pos, left_page_pos = calc_top_bot_page_pos(search_region)
+                    local metric_pos = finale.FCPoint(0, 0)
+                    local mm = finale.FCCellMetrics()
+                    if artic.Visible and artic:CalcMetricPos(metric_pos) and mm:LoadAtEntry(entry) then
+                        local success, top_page_pos, bottom_page_pos, left_page_pos = calc_top_bot_page_pos(search_region)
+                        local this_bottom = note_entry.get_bottom_note_position(entry)
+                        staff_scale = mm.StaffScaling / 10000
+                        top_page_pos = top_page_pos / staff_scale
+                        bottom_page_pos = bottom_page_pos / staff_scale
+                        left_page_pos = left_page_pos / staff_scale
+                        this_bottom = this_bottom / staff_scale
                         local char_width, char_height = articulation.calc_main_character_dimensions(artic_def)
-                        if success then
-        --                    finenv.UI():AlertInfo("t: " .. tostring(top_page_pos) .. " b: " .. tostring(bot_page_pos) .. " l: " .. tostring(left_page_pos), "articulation_autoposition_rolled_chords")
-                        end
+                        local half_char_height = char_height/2
+                        local horz_diff = left_page_pos - metric_pos.X
+                        local vert_diff = top_page_pos - metric_pos.Y
+                        artic.HorizontalPos = artic.HorizontalPos + math.floor(horz_diff - char_width - config.horizontal_padding + 0.5)
+                        artic.VerticalPos = artic.VerticalPos + math.floor(vert_diff - char_height + 2*config.vertical_padding + 0.5)
+                        artic.VerticalCopyToPos = math.floor(bottom_page_pos - this_bottom - config.vertical_padding - half_char_height + 0.5)
+                        save_it = true
                     end
                     if save_it then
                         artic:Save()

--- a/src/articulation_autoposition_rolled_chords.lua
+++ b/src/articulation_autoposition_rolled_chords.lua
@@ -6,7 +6,8 @@ function plugindef()
     finaleplugin.Date = "December 26, 2021"
     finaleplugin.CategoryTags = "Articulation"
     finaleplugin.MinJWLuaVersion = 0.59
-    return "Autoposition Rolled Chord Articulations", "Autoposition Rolled Chord Articulations", "Autoposition Rolled Chord Articulations"
+    return "Autoposition Rolled Chord Articulations", "Autoposition Rolled Chord Articulations",
+            "Creates rolled chords across multiple staves unless shift or option(alt) key is pressed when selecting menu item."
 end
 
 -- This script requires the VerticalCopyToPos property on FCArticulation, which was added in v0.59 of RGP Lua
@@ -29,6 +30,10 @@ local config = {
     --    from looking at illustrations
      horizontal_padding = 18         -- 3/4 space
 }
+
+if finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_ALT) or finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_SHIFT) then
+    config.extend_across_staves = false
+end
 
 function calc_top_bot_page_pos(search_region)
     local success = false

--- a/src/library/articulation.lua
+++ b/src/library/articulation.lua
@@ -57,4 +57,21 @@ function articulation.is_note_side(artic, curr_pos)
     return false
 end
 
+
+--[[
+% calc_main_character_dimensions(artic)
+
+Uses `FCTextMetrics:LoadArticulation` to determine the dimensions of the main character
+
+@ artic_def (FCArticulationDef)
+: (number, number) the width and height of the main articulation character in evpus, or 0, 0 if it failed to load
+]]
+function articulation.calc_main_character_dimensions(artic_def)
+    local text_mets = finale.FCTextMetrics()
+    if not text_mets:LoadArticulation(artic_def, false, 100) then
+        return 0, 0
+    end
+    return math.floor(text_mets:CalcWidthEVPUs() + 0.5), math.floor(text_mets:CalcHeightEVPUs() + 0.5)
+end
+
 return articulation

--- a/src/library/articulation.lua
+++ b/src/library/articulation.lua
@@ -64,14 +64,14 @@ end
 Uses `FCTextMetrics:LoadArticulation` to determine the dimensions of the main character
 
 @ artic_def (FCArticulationDef)
-: (number, number) the width and height of the main articulation character in evpus, or 0, 0 if it failed to load
+: (number, number) the width and height of the main articulation character in (possibly fractional) evpus, or 0, 0 if it failed to load metrics
 ]]
 function articulation.calc_main_character_dimensions(artic_def)
     local text_mets = finale.FCTextMetrics()
     if not text_mets:LoadArticulation(artic_def, false, 100) then
         return 0, 0
     end
-    return math.floor(text_mets:CalcWidthEVPUs() + 0.5), math.floor(text_mets:CalcHeightEVPUs() + 0.5)
+    return text_mets:CalcWidthEVPUs(), text_mets:CalcHeightEVPUs()
 end
 
 return articulation

--- a/src/library/general_library.lua
+++ b/src/library/general_library.lua
@@ -309,6 +309,17 @@ end
 : (boolean)
 ]]
 function library.is_font_smufl_font(font_info)
+    if nil == font_info then
+        font_info = finale.FCFontInfo()
+        font_info:LoadFontPrefs(finale.FONTPREF_MUSIC)
+    end
+    
+    if finenv.RawFinaleVersion >= 0x1b010000 then -- Finale 27.1+, 0x1b == 27
+        if nil ~= font_info.IsSMuFLFont then -- if this version of the lua interpreter has the IsSMuFLFont property (i.e., RGP Lua 0.59+)
+            return font_info.IsSMuFLFont
+        end
+    end
+    
     local smufl_metadata_file = library.get_smufl_metadata_file(font_info)
     if nil ~= smufl_metadata_file then
         io.close(smufl_metadata_file)

--- a/src/library/general_library.lua
+++ b/src/library/general_library.lua
@@ -4,6 +4,25 @@ $module Library
 local library = {}
 
 --[[
+% finale_version(major, minor, build)
+
+Returns a raw Finale version from major, minor, and (optional) build parameters. For 32-bit Finale
+this is the internal major Finale version, not the year.
+
+@ major (number) Major Finale version
+@ minor (number) Minor Finale version
+@ [build] (number) zero if omitted
+: (number)
+]]
+function library.finale_version(major, minor, build)
+    local retval = bit32.bor(bit32.lshift(math.floor(major), 24), bit32.lshift(math.floor(minor), 16))
+    if build then
+        retval = bit32.bor(retval, math.floor(build))
+    end
+    return retval
+end
+
+--[[
 % group_overlaps_region(staff_group, region)
 
 Returns true if the input staff group overlaps with the input music region, otherwise false.
@@ -314,7 +333,7 @@ function library.is_font_smufl_font(font_info)
         font_info:LoadFontPrefs(finale.FONTPREF_MUSIC)
     end
     
-    if finenv.RawFinaleVersion >= 0x1b010000 then -- Finale 27.1+, 0x1b == 27
+    if finenv.RawFinaleVersion >= library.finale_version(27, 1) then
         if nil ~= font_info.IsSMuFLFont then -- if this version of the lua interpreter has the IsSMuFLFont property (i.e., RGP Lua 0.59+)
             return font_info.IsSMuFLFont
         end

--- a/src/library/note_entry.lua
+++ b/src/library/note_entry.lua
@@ -3,9 +3,6 @@ $module Note Entry
 ]]
 local note_entry = {}
 
--- This function may not have been used anywhere, though it has been tested and works.
--- If you use this function, remove this comment.
--- If you remove this function, be sure to check that it still isn't used.
 --[[
 % get_music_region(entry)
 
@@ -39,9 +36,6 @@ local use_or_get_passed_in_entry_metrics = function(entry, entry_metrics)
     return nil, false
 end
 
--- This function may not have been used anywhere, though it has been tested and works.
--- If you use this function, remove this comment.
--- If you remove this function, be sure to check that it still isn't used.
 --[[
 % get_evpu_notehead_height(entry)
 

--- a/src/measure_numbers_adjust_for_leadin.lua
+++ b/src/measure_numbers_adjust_for_leadin.lua
@@ -12,17 +12,17 @@ path:SetRunningLuaFolderPath()
 package.path = package.path .. ";" .. path.LuaString .. "?.lua"
 local library = require("library.general_library")
 
--- Currently the PDK Framework does not appear to provide access to the true barline thickness per measure from the PDK metrics.
--- As a subtitute this sets barline_thickness to your configured single barline thickness in your document prefs (in evpus)
+-- Before v0.59, the PDK Framework did not provide access to the true barline thickness per measure from the PDK metrics.
+-- As a substitute this sets barline_thickness to your configured single barline thickness in your document prefs (in evpus)
 -- This makes it come out right at least for single barlines.
 
 local size_prefs = finale.FCSizePrefs()
 size_prefs:Load(1)
-local barline_thickness = math.floor(size_prefs.ThinBarlineThickness/64.0 + 0.5) -- barline thickness in evpu
+local default_barline_thickness = math.floor(size_prefs.ThinBarlineThickness/64.0 + 0.5) -- barline thickness in evpu
 
 -- additional_offset allows you to tweak the result. it is only applied if the measure number is being moved
 
-local additional_offset = 0 -- here you can add more evpu to taste (positive values move the number to the right)s
+local additional_offset = 0 -- here you can add more evpu to taste (positive values move the number to the right)
 
 function measure_numbers_adjust_for_leadin()
     local systems = finale.FCStaffSystems()
@@ -41,8 +41,9 @@ function measure_numbers_adjust_for_leadin()
             -- getting metrics doesn't work for mm rests (past the first measure) but it takes a really big performance hit, so skip any that aren't first
             -- it is for this reason we are doing our own nested for loops instead of using for cell in each(cells)
             local skip_past_meas_num = 0
+            local previous_meas_num = system_region.StartMeasure
             for meas_num = system_region.StartMeasure, system_region.EndMeasure do
-                if (meas_num > skip_past_meas_num) and sel_region:IsMeasureIncluded(meas_num) then
+                if meas_num > skip_past_meas_num then
                     local meas_num_region = meas_num_regions:FindMeasure(meas_num)
                     if nil ~= meas_num_region then
                         multimeasure_rest = finale.FCMultiMeasureRest()
@@ -50,55 +51,66 @@ function measure_numbers_adjust_for_leadin()
                         if is_for_multimeasure_rest then
                             skip_past_meas_num = multimeasure_rest.EndMeasure
                         end
-                        for slot = system_region.StartSlot, system_region.EndSlot do
-                            local staff = system_region:CalcStaffNumber(slot)
-                            if sel_region:IsStaffIncluded(staff) then
-                                local cell = finale.FCCell(meas_num, staff)
-                                if library.is_default_number_visible_and_left_aligned(meas_num_region, cell, system, current_is_part, is_for_multimeasure_rest) then
-                                    local lead_in = 0
-                                    if cell.Measure ~= system.FirstMeasure then
-                                        local cell_metrics = finale.FCCellMetrics()
-                                        if cell_metrics:LoadAtCell(cell) then
-                                            lead_in = cell_metrics.MusicStartPos - cell_metrics:GetLeftEdge()
-                                            -- FCCellMetrics currently does not provide the barline width, which is available in the underlying PDK struct.
-                                            -- if it did, we would subtract it here. Instead use the valus derived from document settings above.
-                                            lead_in = lead_in - barline_thickness
-                                            if (0 ~= lead_in) then
-                                                lead_in = lead_in - additional_offset
-                                                -- Finale scales the lead_in by the staff percent, so remove that if any
-                                                local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)
-                                                lead_in = math.floor(lead_in/staff_percent + 0.5)
-                                                -- FCSeparateMeasureNumber is scaled horizontally by the horizontal stretch, so back that out
-                                                local horz_percent = cell_metrics.HorizontalStretch / 10000.0
-                                                lead_in = math.floor(lead_in/horz_percent + 0.5)
+                        if sel_region:IsMeasureIncluded(meas_num)  then
+                            for slot = system_region.StartSlot, system_region.EndSlot do
+                                local staff = system_region:CalcStaffNumber(slot)
+                                if sel_region:IsStaffIncluded(staff) then
+                                    local cell = finale.FCCell(meas_num, staff)
+                                    if library.is_default_number_visible_and_left_aligned(meas_num_region, cell, system, current_is_part, is_for_multimeasure_rest) then
+                                        local lead_in = 0
+                                        if cell.Measure ~= system.FirstMeasure then
+                                            local cell_metrics = finale.FCCellMetrics()
+                                            if cell_metrics:LoadAtCell(cell) then
+                                                lead_in = cell_metrics.MusicStartPos - cell_metrics:GetLeftEdge()
+                                                -- FCCellMetrics did not provide the barline width before v0.59.
+                                                -- Use the value derived from document settings above if we can't get the real width.
+                                                local barline_thickness = default_barline_thickness
+                                                if nil ~= cell_metrics.GetRightBarlineWidth then -- if the property getter exists, then we are at 0.59+
+                                                    local previous_cell_metrics = finale.FCCellMetrics()
+                                                    if previous_cell_metrics:LoadAtCell(finale.FCCell(previous_meas_num, staff)) then
+                                                        barline_thickness = previous_cell_metrics.RightBarlineWidth
+                                                        previous_cell_metrics:FreeMetrics()
+                                                    end
+                                                end
+                                                lead_in = lead_in - barline_thickness
+                                                if (0 ~= lead_in) then
+                                                    lead_in = lead_in - additional_offset
+                                                    -- Finale scales the lead_in by the staff percent, so remove that if any
+                                                    local staff_percent = (cell_metrics.StaffScaling / 10000.0) / (cell_metrics.SystemScaling / 10000.0)
+                                                    lead_in = math.floor(lead_in/staff_percent + 0.5)
+                                                    -- FCSeparateMeasureNumber is scaled horizontally by the horizontal stretch, so back that out
+                                                    local horz_percent = cell_metrics.HorizontalStretch / 10000.0
+                                                    lead_in = math.floor(lead_in/horz_percent + 0.5)
+                                                end
                                             end
+                                            cell_metrics:FreeMetrics() -- not sure if this is needed, but it can't hurt
                                         end
-                                        cell_metrics:FreeMetrics() -- not sure if this is needed, but it can't hurt
-                                    end
-                                    local sep_nums = finale.FCSeparateMeasureNumbers()
-                                    sep_nums:LoadAllInCell(cell)
-                                    if (sep_nums.Count > 0) then
-                                        for sep_num in each(sep_nums) do
+                                        local sep_nums = finale.FCSeparateMeasureNumbers()
+                                        sep_nums:LoadAllInCell(cell)
+                                        if (sep_nums.Count > 0) then
+                                            for sep_num in each(sep_nums) do
+                                                sep_num.HorizontalPosition = -lead_in
+                                                sep_num:Save()
+                                            end
+                                        elseif (0 ~= lead_in) then
+                                            local sep_num = finale.FCSeparateMeasureNumber()
+                                            sep_num:ConnectCell(cell)
+                                            sep_num:AssignMeasureNumberRegion(meas_num_region)
                                             sep_num.HorizontalPosition = -lead_in
-                                            sep_num:Save()
-                                        end
-                                    elseif (0 ~= lead_in) then
-                                        local sep_num = finale.FCSeparateMeasureNumber()
-                                        sep_num:ConnectCell(cell)
-                                        sep_num:AssignMeasureNumberRegion(meas_num_region)
-                                        sep_num.HorizontalPosition = -lead_in
-                                        --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. otherwise it will show or hide based on the measure number region
-                                        if sep_num:SaveNew() then
-                                            local measure = finale.FCMeasure()
-                                            measure:Load(cell.Measure)
-                                            measure:SetContainsManualMeasureNumbers(true)
-                                            measure:Save()
+                                            --sep_num:SetShowOverride(true) -- enable this line if you want to force show the number. otherwise it will show or hide based on the measure number region
+                                            if sep_num:SaveNew() then
+                                                local measure = finale.FCMeasure()
+                                                measure:Load(cell.Measure)
+                                                measure:SetContainsManualMeasureNumbers(true)
+                                                measure:Save()
+                                            end
                                         end
                                     end
                                 end
                             end
                         end
                     end
+                    previous_meas_num = meas_num
                 end
             end
         end

--- a/src/prefs_copy_group_hpos_to_staff_hpos.lua
+++ b/src/prefs_copy_group_hpos_to_staff_hpos.lua
@@ -13,6 +13,8 @@ end
 --in Finale 2014.5 where using plugins on a linked part would randomly modify the default staff name positions.
 --Therefore this script is probably of limited use in Finale 26.2 anyway.
 
+--If this script is running in RGP Lua 0.58 or higher, it should work in any version of Finale 25+.
+
 function copy_horizontal_settings_to_staff(group_prefs, staff_prefs)
     staff_prefs.HorizontalPos = group_prefs.HorizontalPos
     staff_prefs.Justification = group_prefs.Justification

--- a/src/standalone_hairpin_adjustment.lua
+++ b/src/standalone_hairpin_adjustment.lua
@@ -30,6 +30,18 @@ local config = {
 
 configuration.get_parameters("standalone_hairpin_adjustment.config.txt", config)
 
+-- In RGP Lua, flip vertical_adjustment_type based on alt/option key when invoked
+
+if finenv.IsRGPLua and finenv.QueryInvokedModifierKeys then
+    if finenv.QueryInvokedModifierKeys(finale.CMDMODKEY_ALT) then
+        if config.vertical_adjustment_type == "far" then
+            config.vertical_adjustment_type = "near"
+        elseif config.vertical_adjustment_type == "near" then
+            config.vertical_adjustment_type = "far"
+        end
+    end
+end
+
 -- end of parameters
 
 function calc_cell_relative_vertical_position(fccell, page_offset)


### PR DESCRIPTION
New features introduced in RGP Lua 0.59 facilitated these various modifications:

- Added `articulation_autoposition_rolled_chords.lua` which uses new properties on `FCArticulation` to position rolled chord symbols.
- Modified `standalone_hairpin_adjustment.lua` to toggle between "near" and "far" based on modifier keys pressed when it is invoked.
- Modified `general_library.is_smufl_font` to use the PDK Framework function when running in Finale 27.1 or higher.
- Modified `measure_numbers_adjust_for_leadin.lua` to use the new `FCCellMetrics.RightBarlineWidth` property to determine the barline width.
